### PR TITLE
Support lib build mode + filter option for dataSetReport

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ A deployable `.zip` file can be found in `build/bundle`!
 
 See the section about [building](https://platform.dhis2.nu/#/scripts/build) for more information.
 
+### `yarn build-lib`
+
+Builds the library for production to the `build` folder.
+
 ### `yarn deploy`
 
 Deploys the built app in the `build` folder to a running DHIS2 instance.<br />

--- a/d2.config.app.js
+++ b/d2.config.app.js
@@ -1,0 +1,11 @@
+module.exports = {
+    type: 'app',
+    name: 'approval',
+    title: 'Data Approval',
+    coreApp: true,
+    id: 'c782611d-73a6-49d8-b252-fe802c0b4d08',
+    minDHIS2Version: '2.37',
+    entryPoints: {
+        app: './src/app/index.js',
+    },
+}

--- a/d2.config.lib.js
+++ b/d2.config.lib.js
@@ -1,0 +1,11 @@
+module.exports = {
+    type: 'lib',
+    name: 'approval',
+    title: 'Data Approval',
+    coreApp: false,
+    id: 'c782611d-73a6-49d8-b252-fe802c0b4d08',
+    minDHIS2Version: '2.37',
+    entryPoints: {
+        lib: './src/app/index.js',
+    },
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "license": "BSD-3-Clause",
     "private": true,
     "scripts": {
-        "build": "d2-app-scripts build",
+        "build": "cp d2.config.app.js d2.config.js && d2-app-scripts build",
+        "build-lib": "cp d2.config.lib.js d2.config.js && d2-app-scripts build",
         "deploy": "d2-app-scripts deploy",
         "format": "d2-style apply",
         "format:staged": "d2-style apply --staged",
@@ -45,5 +46,11 @@
         "prop-types": "^15.7.2",
         "query-string": "^7.0.1",
         "use-debounce": "^7.0.0"
+    },
+    "main": "./build/cjs/app/index.js",
+    "module": "./build/es/app/index.js",
+    "exports": {
+        "import": "./build/es/app/index.js",
+        "require": "./build/cjs/app/index.js"
     }
 }

--- a/package.lib.json
+++ b/package.lib.json
@@ -5,8 +5,7 @@
     "license": "BSD-3-Clause",
     "private": true,
     "scripts": {
-        "build": "cp d2.config.app.js d2.config.js && d2-app-scripts build",
-        "build-lib": "cp d2.config.lib.js d2.config.js && d2-app-scripts build && cp package.json build/",
+        "build": "d2-app-scripts build",
         "deploy": "d2-app-scripts deploy",
         "format": "d2-style apply",
         "format:staged": "d2-style apply --staged",
@@ -47,10 +46,10 @@
         "query-string": "^7.0.1",
         "use-debounce": "^7.0.0"
     },
-    "main": "./build/cjs/app/index.js",
-    "module": "./build/es/app/index.js",
+    "main": "./cjs/app/index.js",
+    "module": "./es/app/index.js",
     "exports": {
-        "import": "./build/es/app/index.js",
-        "require": "./build/cjs/app/index.js"
+        "import": "./es/app/index.js",
+        "require": "./cjs/app/index.js"
     }
 }

--- a/src/data-workspace/display/display.js
+++ b/src/data-workspace/display/display.js
@@ -14,18 +14,19 @@ import { Table } from './table.js'
 const query = {
     dataSetReport: {
         resource: 'dataSetReport',
-        params: ({ dataSetId, periodIds, orgUnit }) => ({
+        params: ({ dataSetId, periodIds, orgUnit, filter }) => ({
             // arrays are being handled by the app runtime
             pe: periodIds,
             ds: dataSetId,
             ou: orgUnit.id,
+            filter: filter,
         }),
     },
 }
 
 const Display = ({ dataSetId }) => {
     const selection = useSelectionContext()
-    const { orgUnit, workflow, period } = selection
+    const { orgUnit, workflow, period, filter } = selection
     const { dataSets } = workflow
     const selectedDataSet = dataSets.find(({ id }) => id === dataSetId)
     const periodIds = selectedDataSet
@@ -40,7 +41,8 @@ const Display = ({ dataSetId }) => {
         lazy: true,
     })
     const tables = data?.dataSetReport
-    const fetchDataSet = () => refetch({ periodIds, dataSetId, orgUnit })
+    const fetchDataSet = () =>
+        refetch({ periodIds, dataSetId, orgUnit, filter })
 
     useEffect(
         () => {

--- a/src/selection-context/selection-context.js
+++ b/src/selection-context/selection-context.js
@@ -8,9 +8,11 @@ const SelectionContext = createContext({
     workflow: {},
     period: {},
     orgUnit: {},
+    filter: '',
     selectWorkflow: defaultFn,
     selectPeriod: defaultFn,
     selectOrgUnit: defaultFn,
+    selectFilter: defaultFn,
     clearAll: defaultFn,
     setOpenedSelect: defaultFn,
 })

--- a/src/selection-context/selection-provider.js
+++ b/src/selection-context/selection-provider.js
@@ -82,7 +82,7 @@ const reducer = (state, { type, payload }) => {
     }
 }
 
-const SelectionProvider = ({ children }) => {
+const SelectionProvider = ({ disableHistory, children }) => {
     const { dataApprovalWorkflows } = useAppContext()
     const [
         { openedSelect, workflow, period, orgUnit, dataSet, filter },
@@ -126,6 +126,7 @@ const SelectionProvider = ({ children }) => {
     }
 
     useEffect(() => {
+        if (disableHistory === true) return
         pushStateToHistory({ workflow, period, orgUnit, dataSet })
     }, [workflow, period, orgUnit, dataSet])
 

--- a/src/selection-context/selection-provider.js
+++ b/src/selection-context/selection-provider.js
@@ -12,6 +12,7 @@ const ACTIONS = {
     SELECT_PERIOD: 'SELECT_PERIOD',
     SELECT_ORG_UNIT: 'SELECT_ORG_UNIT',
     SELECT_DATA_SET: 'SELECT_DATA_SET',
+    SELECT_FILTER: 'SELECT_FILTER',
     SET_STATE_FROM_QUERY_PARAMS: 'SET_STATE_FROM_QUERY_PARAMS',
 }
 
@@ -29,6 +30,7 @@ const reducer = (state, { type, payload }) => {
                 period: null,
                 orgUnit: null,
                 dataSet: null,
+                filter: '',
             }
         case ACTIONS.SELECT_WORKFLOW:
             return {
@@ -65,6 +67,11 @@ const reducer = (state, { type, payload }) => {
                 ...state,
                 dataSet: payload.dataSet,
             }
+        case ACTIONS.SELECT_FILTER:
+            return {
+                ...state,
+                filter: payload.filter,
+            }
         case ACTIONS.SET_STATE_FROM_QUERY_PARAMS:
             return {
                 openedSelect: '',
@@ -77,16 +84,19 @@ const reducer = (state, { type, payload }) => {
 
 const SelectionProvider = ({ children }) => {
     const { dataApprovalWorkflows } = useAppContext()
-    const [{ openedSelect, workflow, period, orgUnit, dataSet }, dispatch] =
-        useReducer(reducer, {
-            openedSelect: '',
-            ...initialValues(dataApprovalWorkflows),
-        })
+    const [
+        { openedSelect, workflow, period, orgUnit, dataSet, filter },
+        dispatch,
+    ] = useReducer(reducer, {
+        openedSelect: '',
+        ...initialValues(dataApprovalWorkflows),
+    })
 
     const providerValue = {
         workflow,
         period,
         orgUnit,
+        filter,
         openedSelect,
         dataSet,
         clearAll: () =>
@@ -111,6 +121,8 @@ const SelectionProvider = ({ children }) => {
             dispatch({ type: ACTIONS.SELECT_ORG_UNIT, payload: { orgUnit } }),
         selectDataSet: (dataSet) =>
             dispatch({ type: ACTIONS.SELECT_DATA_SET, payload: { dataSet } }),
+        selectFilter: (filter) =>
+            dispatch({ type: ACTIONS.SELECT_FILTER, payload: { filter } }),
     }
 
     useEffect(() => {


### PR DESCRIPTION
Required by https://app.clickup.com/t/86942d0mj

- [x] Add "yarn build-lib" task.
- [x] Add support for dataSetReport param: filter. Example: `filter=ao:ID`
- [x] Add option to SelectionProvider to disable URL sync
- [x] Note that when using with "yarn link", you have to copy the `build/` somewhere else (/tmp for example, someplace there is no parent folder with node_modules), and do "yarn link" there. Otherwise, CRA will get the react from the parent node_modules and it will fail as 2 React are loaded at the same time.

The build process is not as smooth as we'd like, AFICS we are forced to overwrite d2.config.js (see cli-app-scripts/src/lib/paths.js), but it's ok for a first approach. We'd want to discuss the approach with upstream.